### PR TITLE
Fix reduce_db_reporting for Radar Energy

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -440,14 +440,14 @@ sensor:
       id: radar_moving_energy
       filters:
         - lambda: |-
-            if (reduce_db_reporting) return {};
+            if (id(reduce_db_reporting).state) return {};
             return x;
     still_energy:
       name: Radar Still Energy
       id: radar_still_energy
       filters:
         - lambda: |-
-            if (reduce_db_reporting) return {};
+            if (id(reduce_db_reporting).state) return {};
             return x;
     detection_distance:
       name: Radar Detection Distance


### PR DESCRIPTION
This PR fixes the reporting of Radar Still Energy and Radar Move Energy depending on the state of `reduce_db_reporting`