### PR TITLE
Fixing compatibility with ESPHome 2025.2.0

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-msr-2
-  version:  "24.7.15.1"
+  version:  "25.2.19.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   
 esp32:
@@ -447,7 +447,6 @@ light:
     id: rgb_light
     name: "RGB Light"
     pin: GPIO3
-    rmt_channel: 0
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 3

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -29,7 +29,7 @@ esphome:
     name: "ApolloAutomation.MSR-2"
     version: "${version}"
 
-  min_version: 2024.6.0
+  min_version: 2025.2.0
 
 # Define Board
 esp32:

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -498,7 +498,6 @@ light:
     id: rgb_light
     name: "RGB Light"
     pin: GPIO3
-    rmt_channel: 0
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 3

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -1,7 +1,7 @@
 #Define Project
 substitutions:
   name: apollo-msr-2
-  version:  "24.7.15.1"
+  version:  "25.2.19.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   
 esphome:

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -23,7 +23,7 @@ esphome:
     name: "ApolloAutomation.MSR-2"
     version: "${version}"
 
-  min_version: 2024.6.4
+  min_version: 2025.2.0
 
   
 dashboard_import:

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -42,8 +42,4 @@ bluetooth_proxy:
   active: true
 
 packages:
-  ApolloAutomation.TEMP-1:
-    url: https://github.com/ApolloAutomation/MSR-2
-    ref: beta
-    files: [Integrations/ESPHome/TEMP-1_Minimal.yaml]
-    refresh: 1min
+  core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -42,9 +42,8 @@ bluetooth_proxy:
   active: true
 
 packages:
-  remote_package:
-    url: https://github.com/ApolloAutomation/MSR-2/
-    ref: main
-    files:
-      - Integrations/ESPHome/Core.yaml
-    refresh: 0d
+  ApolloAutomation.TEMP-1:
+    url: https://github.com/ApolloAutomation/MSR-2
+    ref: beta
+    files: [Integrations/ESPHome/TEMP-1_Minimal.yaml]
+    refresh: 1min

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -53,9 +53,8 @@ ota:
 
 
 packages:
-  remote_package:
-    url: https://github.com/ApolloAutomation/MSR-2/
-    ref: main
-    files:
-      - Integrations/ESPHome/Core.yaml
-    refresh: 0d
+  ApolloAutomation.TEMP-1:
+    url: https://github.com/ApolloAutomation/MSR-2
+    ref: beta
+    files: [Integrations/ESPHome/TEMP-1_Minimal.yaml]
+    refresh: 1min

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -22,7 +22,7 @@ esphome:
     name: "ApolloAutomation.MSR-2"
     version: "${version}"
 
-  min_version: 2024.6.4
+  min_version: 2025.2.0
 
   
 dashboard_import:

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -50,11 +50,5 @@ ota:
   - platform: esphome
     id: ota_esphome
 
-
-
 packages:
-  ApolloAutomation.TEMP-1:
-    url: https://github.com/ApolloAutomation/MSR-2
-    ref: beta
-    files: [Integrations/ESPHome/TEMP-1_Minimal.yaml]
-    refresh: 1min
+  core: !include Core.yaml


### PR DESCRIPTION
Version:
25.2.19.1

Adds:
NA

Fixes:
Remove `rmt_channel` from configuration to make it compatible with ESPHome 2025.2.0

Breaks:
Compatibility with older versions of ESPHome


Checks:
- [X] Documentation Updated
- [X] Build Number Incremented In YAML (YY.MM.DD.#)

