### PR TITLE
Update MSR-2_BLE.yaml to use correct ble proxy

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-msr-2
-  version:  "25.2.21.2"
+  version:  "25.5.9.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   
 esp32:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-msr-2
-  version:  "25.5.9.1"
+  version:  "25.6.24.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   
 esp32:

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -40,6 +40,9 @@ ota:
 
 bluetooth_proxy:
   active: true
+esp32_ble_tracker:
+  scan_parameters:
+    active: false
 
 packages:
   core: !include Core.yaml


### PR DESCRIPTION
Update MSR-2_BLE.yaml to use correct ble proxy

needed all 5 lines not 2.

Version:

Adds:

Fixes:

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In YAML (YY.MM.DD.#)

