### PR TITLE
add logger to ble fork

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-msr-2
-  version:  "25.2.21.2"
+  version:  "25.7.29.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   
 esp32:

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -25,6 +25,7 @@ esphome:
 
   min_version: 2025.2.0
 
+logger:
   
 dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-2/Integrations/ESPHome/MSR-2_BLE.yaml


### PR DESCRIPTION
Version:
25.7.29.1
Adds:

Fixes:
implements logger in the BLE fork
Breaks:



Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In YAML (YY.MM.DD.#)

