### PR TITLE
Add configurable update interval for LTR390 sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -164,6 +164,7 @@ number:
   - platform: template
     name: LTR390 Update Interval
     id: ltr390_update_interval
+    disabled_by_default: true
     restore_value: true
     initial_value: 60
     min_value: 1


### PR DESCRIPTION
## Summary

This PR implements the configurable update interval requested in #54 for the LTR390 light sensor.

- **LTR390 Update Interval**: Allows users to adjust the sensor update frequency from the default 60 seconds to any value between 1-300 seconds

## Changes

### Number Input Added
- `LTR390 Update Interval` - Configurable sensor polling rate (1-300 seconds, default: 60s)

### Sensor Configuration Updates
- Set LTR390 `update_interval` to `never` (disables automatic polling)
- Added global variable `ltr390_last_update` to track last sensor update time
- Added `interval` component that runs every 1 second to check if configured interval has elapsed
- Manually triggers sensor update via `component.update()` when needed

## Technical Details

**Why use interval component?**
ESPHome sensor platforms don't support templatable `update_interval` parameters. Attempting to use a lambda for `update_interval` results in compilation error: "This option is not templatable!"

**How it works:**
1. LTR390 sensor automatic updates are disabled (`update_interval: never`)
2. A 1-second interval checks elapsed time since last update
3. When configured interval is reached, manually triggers `id(ltr_390).update()`
4. Tracks update time in global variable for next interval calculation

**The setting:**
- Uses ESPHome template number platform
- Is categorized as CONFIG entity for proper grouping in the web UI
- Persists values across device reboots (`restore_value: true`)
- Is immediately accessible through the device's web interface on port 80
- Updates take effect immediately without reboot

## Benefits

Users can now adjust the LTR390 sensor update frequency without:
- Editing YAML configuration files
- Recompiling firmware
- Reflashing the device
- Rebooting the device

Simply adjust the value through the web interface and the sensor will update at the new interval.

## Testing

- YAML syntax validated
- Configuration follows existing patterns (similar to DPS Temperature Offset)
- Backward compatible (uses default value of 60s matching current behavior)
- Interval component approach is standard ESPHome pattern for dynamic timing

## Resolves

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable update-interval setting for the LTR390 light sensor to control reading frequency.
* **Improvements**
  * Sensor now uses interval-based polling for consistent, timed updates.
  * Added internal tracking of the last update time to ensure accurate scheduling and prevent redundant readings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->