### PR TITLE
Add boot status LED feature and firmware version sensors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -43,10 +43,27 @@ globals:
     restore_value: no
     type: bool
     initial_value: "false"
+  - id: first_boot_done
+    restore_value: no
+    type: bool
+    initial_value: "false"
+  - id: boot_status_enabled
+    restore_value: yes
+    type: bool
+    initial_value: "true"
 
 # Enable Home Assistant API
 # Also Add Buzzer Service Connection
 api:
+  on_client_connected:
+    then:
+      - delay: 1s  # Let connection stabilize before showing status
+      - if:
+          condition:
+            - lambda: 'return !id(first_boot_done) && id(boot_status_enabled);'
+          then:
+            - lambda: 'id(first_boot_done) = true;'
+            - script.execute: statusCheck
   services:
     - service: play_buzzer
       variables:
@@ -314,10 +331,8 @@ binary_sensor:
             if (millis() - id(button_press_timestamp) >= 8000) {
               id(factory_reset_switch).turn_on();
             }
-            else if (millis() - id(button_press_timestamp) >= 1000) {
-              id(testCycleCount) = 0;
-              id(runTest) = true;
-              id(testScript).execute();
+            else if (millis() - id(button_press_timestamp) >= 2000) {
+              id(diagnosticCheck).execute();
             }
 
   - platform: template
@@ -700,6 +715,18 @@ switch:
     id: factory_reset_switch
     internal: true
   - platform: template
+    name: "Boot Status LED"
+    id: boot_status_led_switch
+    icon: mdi:led-on
+    entity_category: "config"
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    lambda: 'return id(boot_status_enabled);'
+    turn_on_action:
+      - lambda: 'id(boot_status_enabled) = true;'
+    turn_off_action:
+      - lambda: 'id(boot_status_enabled) = false;'
+  - platform: template
     name: "Reduce DB Reporting"
     id: reduce_db_reporting
     icon: mdi:database
@@ -713,6 +740,17 @@ text_sensor:
     version:
       name: "Radar Firmware Version"
 
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
+
 select:
   - platform: ld2410
     distance_resolution:
@@ -722,7 +760,55 @@ select:
 
 
 script:
-  - id: testScript      
+  - id: statusCheck
+    mode: single  # First call runs to completion, subsequent calls ignored
+    then:
+      - if:
+          condition:
+            - lambda: 'return id(ink_ha_connected).state;'
+          then:
+            - logger.log: "Apollo Automation: Connected To HA"
+            - light.turn_on:
+                id: rgb_light
+                brightness: 100%
+                red: 0%
+                green: 0%
+                blue: 100%
+          else:
+            - if:
+                condition:
+                  - wifi.connected
+                then:
+                  - logger.log: "Apollo Automation: Connected To Wifi"
+                  - light.turn_on:
+                      id: rgb_light
+                      brightness: 100%
+                      red: 0%
+                      green: 100%
+                      blue: 0%
+                else:
+                  - logger.log: "Apollo Automation: Not Connected To Wifi"
+                  - light.turn_on:
+                      id: rgb_light
+                      brightness: 100%
+                      red: 100%
+                      green: 100%
+                      blue: 0%
+      - delay: 5s
+      - light.turn_off: rgb_light
+
+  - id: diagnosticCheck
+    mode: single
+    then:
+      - script.execute: statusCheck
+      - script.wait: statusCheck
+      - delay: 3s
+      - lambda: |-
+          id(testCycleCount) = 0;
+          id(runTest) = true;
+      - script.execute: testScript
+
+  - id: testScript
     then:
       if: 
         condition:

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -36,12 +36,18 @@ ota:
     id: ota_default
 
 wifi:
-
   power_save_mode: none
-
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "Apollo MSR2 Hotspot"
+  on_connect:
+    then:
+      - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
+      - if:
+          condition:
+            - lambda: 'return !id(first_boot_done) && id(boot_status_enabled);'
+          then:
+            - lambda: 'id(first_boot_done) = true;'
+            - script.execute: statusCheck
 
 
 packages:

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -34,6 +34,15 @@ dashboard_import:
 wifi:
   ap:
     ssid: "Apollo MSR2 Hotspot"
+  on_connect:
+    then:
+      - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
+      - if:
+          condition:
+            - lambda: 'return !id(first_boot_done) && id(boot_status_enabled);'
+          then:
+            - lambda: 'id(first_boot_done) = true;'
+            - script.execute: statusCheck
 
 ota:
   - platform: esphome

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -37,8 +37,15 @@ esp32_improv:
 
 wifi:
   on_connect:
-    - delay: 5s  
+    - delay: 5s
     - ble.disable:
+    - delay: 5s  # Additional delay (total 10s) for HA to connect
+    - if:
+        condition:
+          - lambda: 'return !id(first_boot_done) && id(boot_status_enabled);'
+        then:
+          - lambda: 'id(first_boot_done) = true;'
+          - script.execute: statusCheck
   on_disconnect:
     - ble.enable:
   ap:


### PR DESCRIPTION
## Summary
- Add boot status LED that shows connection status on boot (blue=HA, green=WiFi, yellow=not connected)
- Add "Boot Status LED" toggle switch to enable/disable the feature
- Add "ESPHome Version" and "Apollo Firmware Version" text sensors
- Update button timing: 2-8s hold runs both statusCheck and testScript

## New Features
- **Boot Status LED**: Shows connection status for 5 seconds after boot
  - 🔵 Blue = Connected to Home Assistant
  - 🟢 Green = WiFi only
  - 🟡 Yellow = Not connected
- **Toggle Switch**: "Boot Status LED" in Config to enable/disable (on by default)
- **Manual Diagnostic**: Hold reset button 2-8 seconds to run connection check + hardware test
- **Firmware Version Sensors**: ESPHome and Apollo versions now visible in HA

## Button Timing
| Duration | Action |
|----------|--------|
| < 2s | Nothing |
| 2-8s | statusCheck → 3s wait → testScript |
| 8s+ | WiFi reset |

## Testing
Same as MTR-1 testing guide - see MTR-1 PR #75 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added controllable boot diagnostics toggle switch for managing startup status reporting.
  * Diagnostic information now displays firmware and ESPHome versions in the UI.
  * Boot status checks trigger on first device connection with visual LED indicators.
  * Enhanced button long-press diagnostics with comprehensive multi-condition evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->