### PR TITLE
[version] Add ESPHome version and Apollo firmware version sensors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -723,7 +723,6 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
-    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version


### PR DESCRIPTION
Version: 25.8.12.1

## What does this implement/fix?

Adds two diagnostic text sensors to `Core.yaml`, ported from [MTR-1 PR #79](https://github.com/ApolloAutomation/MTR-1/pull/79):

- **ESPHome Version** — exposes the running ESPHome version via the `version` platform (timestamp hidden)
- **Apollo Firmware Version** — exposes the `${version}` substitution variable as a diagnostic entity via the `template` platform

These sensors make firmware and ESPHome version visible in Home Assistant for diagnostics and automation without requiring any other changes.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page