### PR TITLE
[api] Rename services to actions

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -45,18 +45,18 @@ globals:
     initial_value: "false"
 
 # Enable Home Assistant API
-# Also Add Buzzer Service Connection
+# Also Add Buzzer Action Connection
 api:
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:
         - rtttl.play:
             rtttl: !lambda 'return song_str;'
 
-    #Co2 Calibration Service
-    - service: calibrate_co2_value
+    #Co2 Calibration Action
+    - action: calibrate_co2_value
       variables:
         co2_ppm: float
       then:
@@ -65,7 +65,7 @@ api:
             id: scd40
 
     #Setting HLK Password
-    - service: set_ld2410_bluetooth_password
+    - action: set_ld2410_bluetooth_password
       variables:
         password: string
       then:


### PR DESCRIPTION
Version: 25.8.12.1

## What does this implement/fix?

Renames `services:`/`service:` to `actions:`/`action:` in the `api:` block of `Core.yaml` to match the current ESPHome API convention. Applies to all three entries: `play_buzzer`, `calibrate_co2_value`, and `set_ld2410_bluetooth_password`.

**⚠️ Breaking change:** Any Home Assistant automations or scripts that call these as HA services (e.g. `esphome.apollo_msr_2_play_buzzer`) will need to be updated to use the new action syntax after flashing this firmware.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page