### PR TITLE
[esphome] Modernise board spec and remove legacy platformio/BLE config

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -4,7 +4,8 @@ substitutions:
   device_description: ${name} made by Apollo Automation - version ${version}.
   
 esp32:
-  board: esp32-c3-devkitm-1
+  variant: esp32c3
+  flash_size: 4MB
   framework:
     type: esp-idf
 

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo MSR-2
   comment: Apollo MSR-2
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   on_boot:
   - priority: 900.0
     then:

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo MSR-2
   comment: Apollo MSR-2
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   on_boot:
   - priority: 900.0
     then:

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -3,8 +3,6 @@ esphome:
   friendly_name: Apollo MSR-2
   comment: Apollo MSR-2
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
   on_boot:
   - priority: 900.0
     then:
@@ -36,11 +34,6 @@ esp32_improv:
   authorizer: none
 
 wifi:
-  on_connect:
-    - delay: 5s  
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo MSR2 Hotspot"
 


### PR DESCRIPTION
Version: 25.8.12.1

## What does this implement/fix?

Ports the non-breaking modernisation changes from [MTR-1 PR #74](https://github.com/ApolloAutomation/MTR-1/pull/74) to the MSR-2 (`web_server: version: 3` was already present):

**`Core.yaml`**
- `esp32`: replaced `board: esp32-c3-devkitm-1` with `variant: esp32c3` + `flash_size: 4MB` (new ESPHome board spec)

**`MSR-2.yaml`, `MSR-2_BLE.yaml`, `MSR-2_Factory.yaml`**
- Removed `platformio_options: board_build.flash_mode: dio` (no longer needed with the new variant spec)

**`MSR-2_Factory.yaml`**
- Removed legacy `on_connect`/`on_disconnect` BLE enable/disable wifi hooks

Note: `min_version` was intentionally not changed. The `services` → `actions` rename is handled separately in its own breaking-change PR.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page