### PR TITLE
[apollo_msr-2] Add configurable DPS310 pressure offset

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -358,10 +358,6 @@ sensor:
         - lambda: |-
             static float last_reported_value = -6.0;
             float current_value = x;
-            float offset = id(dps310_pressure_offset).state;
-            if (!isnan(offset)) {
-              current_value += offset;
-            }
 
             // Check if the reduce_db_reporting switch is on
             if (id(reduce_db_reporting).state) {
@@ -579,10 +575,6 @@ sensor:
         - lambda: |-
             static float last_reported_value = -21.0;
             float current_value = x;
-            float offset = id(dps310_pressure_offset).state;
-            if (!isnan(offset)) {
-              current_value += offset;
-            }
 
             // Check if the reduce_db_reporting switch is on
             if (id(reduce_db_reporting).state) {
@@ -606,10 +598,6 @@ sensor:
         - lambda: |-
             static float last_reported_value = -21.0;
             float current_value = x;
-            float offset = id(dps310_pressure_offset).state;
-            if (!isnan(offset)) {
-              current_value += offset;
-            }
 
             // Check if the reduce_db_reporting switch is on
             if (id(reduce_db_reporting).state) {


### PR DESCRIPTION
## What does this implement/fix?

Adds a user-configurable DPS310 Pressure Offset (CONFIG, -100 to +100 hPa, 0.1 step, persists across reboots). The offset is applied in the existing pressure filter lambda before the delta-reporting check, with an isnan() guard for safety during startup.

## Types of changes
- [x] New feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "DPS310 Pressure Offset" setting to fine‑tune pressure readings; disabled by default, restores value on restart, initial 0.0, adjustable -100 to 100 hPa with 0.1 step, shown as a box control, and uses optimistic updates.
  * Pressure sensor readings now apply the configured offset; existing temperature offset behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->