### PR TITLE
Enable CO2 auto calibration by default with toggle to disable

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-msr-2
-  version: "26.3.2.1"
+  version: "26.6.10.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   
 esp32:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -409,7 +409,7 @@ sensor:
     co2:
       name: "CO2"
       id: "co2"
-    automatic_self_calibration: false
+    automatic_self_calibration: true
     update_interval: 60s
     measurement_mode: "periodic"
     i2c_id: bus_a
@@ -767,6 +767,23 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: "config"
+  - platform: template
+    name: "CO2 Auto Calibration"
+    id: co2_auto_calibration
+    icon: mdi:molecule-co2
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    entity_category: "config"
+    on_turn_on:
+      then:
+        - script.execute:
+            id: setCo2AutoCalibration
+            enable: true
+    on_turn_off:
+      then:
+        - script.execute:
+            id: setCo2AutoCalibration
+            enable: false
 
 
 text_sensor:
@@ -798,7 +815,37 @@ select:
 
 
 script:
-  - id: testScript      
+  - id: setCo2AutoCalibration
+    mode: restart
+    parameters:
+      enable: bool
+    then:
+      #The SCD40 forgets this setting on power loss and the scd4x component
+      #re-applies the YAML default during setup (~1.5s after boot), so when this
+      #runs at boot (via the restored switch state) wait for setup to finish first.
+      - if:
+          condition:
+            lambda: "return millis() < 20000;"
+          then:
+            - delay: 20s
+      #The sensor only accepts the ASC command while idle, so stop periodic
+      #measurement first, then restart it. Same sequence the component uses
+      #for forced calibration.
+      - lambda: |-
+          id(scd40).write_command((uint16_t) 0x3F86); //stop periodic measurement
+      - delay: 500ms
+      - lambda: |-
+          id(scd40).set_automatic_self_calibration(enable);
+          if (!id(scd40).write_command((uint16_t) 0x2416, (uint16_t) (enable ? 1 : 0))) {
+            ESP_LOGE("Apollo", "Failed to set CO2 auto calibration");
+          } else {
+            ESP_LOGI("Apollo", "CO2 auto calibration %s", enable ? "enabled" : "disabled");
+          }
+      - delay: 10ms
+      - lambda: |-
+          id(scd40).write_command((uint16_t) 0x21B1); //start periodic measurement
+
+  - id: testScript
     then:
       if: 
         condition:


### PR DESCRIPTION
﻿<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.6.10.1

## What does this implement/fix?

Enables the SCD40's automatic self-calibration (ASC) by default and adds a "CO2 Auto Calibration" switch so users can turn it off.

- With ASC on (the new default, matching the ESPHome default), the sensor corrects its own baseline as long as it sees fresh air (about 420 ppm) at least once a week. The manual 420 ppm recalibration every 1-2 years is no longer needed for most homes.
- The new switch is visible under Configuration, defaults to on, and persists across reboots and updates. Toggling takes effect immediately: the script stops periodic measurement, sends the ASC command over I2C (using the scd4x component's public `write_command`), and restarts measurement, the same sequence the component uses for forced calibration. The saved choice is re-applied ~20 seconds after every boot, since the SCD40 loses the setting on power loss and ESPHome re-applies the YAML default during setup.
- The "Calibrate SCD40 To 420ppm" button and the `calibrate_co2_value` action are unchanged and keep working whether ASC is on or off.
- Version bumped to 26.6.10.1.

**Why a breaking change:** existing devices get ASC turned on when they update. Readings may shift over the first days as the baseline self-corrects. Users whose device sits in a space that rarely gets fresh air (a sealed office, a basement, a grow room) should turn the new switch off and keep calibrating manually. Suggest including this in the release notes.

The same change is rolling out to AIR-1 and MTR-1 (identical), and R_PRO-1 (toggle fix/rename; its ASC was already on by default). A wiki update covering all four products is ready to merge alongside the firmware releases.

Verification: `esphome compile` passes for MSR-2.yaml, MSR-2_BLE.yaml, and MSR-2_Factory.yaml (ESPHome 2026.1.3). Not yet tested on hardware.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [x] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Apollo Automation version to 26.6.10.1
  * Enabled automatic self-calibration for CO2 sensor by default
  * Added CO2 Auto Calibration toggle switch to manually control automatic calibration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->