### PR TITLE
Add managed firmware update system

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,7 @@ name-template: 'Release v$NEXT_PATCH_VERSION'
 tag-template: "$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
+category-template: '**$TITLE**'
 
 categories:
   - title: "🚨 Breaking changes"
@@ -25,11 +26,9 @@ include-labels:
 
 no-changes-template: '- No changes'
 
+# The shared build workflow appends a Full Changelog compare link to the
+# release body (release-drafter cannot render 4-part version tags).
 template: |
-  ## What's Changed
+  **What's Changed**
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/ApolloAutomation/MSR-2/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
-
-   Be sure to 🌟 this repository for updates!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
       device-name: msr-2
       yaml-files: |
         Integrations/ESPHome/MSR-2_Factory.yaml
-      firmware-names: "2_Factory:firmware"
+        Integrations/ESPHome/MSR-2_BLE.yaml
+      firmware-names: "2_Factory:firmware,2_BLE:firmware-ble"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -36,6 +36,8 @@ logger:
 ota:
   - platform: esphome
     id: ota_default
+  - platform: http_request
+    id: ota_managed
 
 wifi:
 
@@ -45,6 +47,17 @@ wifi:
   ap:
     ssid: "Apollo MSR2 Hotspot"
 
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MSR-2/firmware/manifest.json
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -40,6 +40,8 @@ ota:
     id: ota_managed
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
 
   power_save_mode: none
 

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -25,7 +25,7 @@ esphome:
     name: "ApolloAutomation.MSR-2"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
   
 dashboard_import:
   package_import_url: github://ApolloAutomation/MSR-2/Integrations/ESPHome/MSR-2.yaml

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -34,6 +34,8 @@ dashboard_import:
   import_full_config: false
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo MSR2 Hotspot"
 

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -40,12 +40,25 @@ wifi:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
 
 bluetooth_proxy:
   active: true
 esp32_ble_tracker:
   scan_parameters:
     active: false
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MSR-2/firmware-ble/manifest.json
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -25,7 +25,7 @@ esphome:
     name: "ApolloAutomation.MSR-2_BLE"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
 
 logger:
   

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -25,7 +25,7 @@ esphome:
     name: "ApolloAutomation.MSR-2_Factory"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
 
   
 dashboard_import:

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -47,6 +47,19 @@ logger:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MSR-2/firmware/manifest.json
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -39,6 +39,8 @@ esp32_improv:
   authorizer: none
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo MSR2 Hotspot"
 


### PR DESCRIPTION
Ports the managed OTA update system from R_PRO-1 to all MSR-2 variants, so devices can self-update from the GitHub Pages manifests directly in Home Assistant. MSR-2 already publishes `firmware/manifest.json` to Pages; this adds the device-side half.

## Changes

- `update: http_request` component (Firmware Update entity in HA) + `ota: http_request` platform on all three variants
- `safe_mode` for boot-loop recovery after a bad flash
- `http_request` with `verify_ssl: true` (esp-idf TLS, same as R_PRO-1)
- BLE variant is now built and published by CI to its own `firmware-ble/` manifest, and `MSR-2_BLE.yaml` updates from it — without this, a BLE device taking an update would be silently converted to the factory (non-BLE) firmware and lose Bluetooth proxy
- Manifest check triggered on `wifi.on_connect`: the update component's first 6-hour poll fires before the network is up and skips silently, leaving the entity stale for ~6h after every boot (R_PRO-1 has this today). The trigger makes the entity accurate within seconds of boot.
- `min_version` raised to 2025.11.0 to match the floor R_PRO-1 set when this system landed there

## Testing

The identical port was tested end to end on a physical MTR-1 (factory and BLE manifest paths): flash → update offered in HA with release notes → OTA install from Pages → reboot on new version → Bluetooth proxy intact on the BLE variant. All three MSR-2 variants compile-verified on ESPHome 2026.1.3.

Note for support: devices need outbound HTTPS (443) to `apolloautomation.github.io` — isolated IoT VLANs that block egress will show "up to date" forever with `ESP_ERR_HTTP_CONNECT` in debug logs.