### PR TITLE
Unified firmware: runtime Bluetooth Proxy switch + Stable/Beta channel OTA

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,0 +1,105 @@
+name: Build and Publish Beta
+
+# Builds MSR-2 firmware from the beta branch and publishes it as assets on a
+# rolling "beta-fw" pre-release. The on-device "Firmware Channel" select points
+# OTA updates at these assets. Stable firmware is built/published separately
+# by build.yml (push to main -> GitHub Pages).
+
+on:
+  push:
+    branches: [beta]
+    paths:
+      - 'Integrations/ESPHome/**'
+  workflow_dispatch:
+
+# Least privilege: read-only by default; only publish-beta is elevated to write.
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Read version
+    runs-on: ubuntu-latest
+    outputs:
+      v: ${{ steps.read.outputs.v }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - id: read
+        run: |
+          v=$(awk '/substitutions:/ {f=1} f && /version:/ {print $2; exit}' \
+            Integrations/ESPHome/Core.yaml | tr -d '"')
+          echo "v=$v" >> "$GITHUB_OUTPUT"
+          echo "Beta version: $v"
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: version
+    strategy:
+      matrix:
+        include:
+          # Beta serves OTA updates only, so it builds the end-user image
+          # (MSR-2.yaml), not the first-flash Factory image.
+          - { yaml: Integrations/ESPHome/beta-channel/MSR-2.yaml,     name: firmware-standard }
+          - { yaml: Integrations/ESPHome/beta-channel/MSR-2_BLE.yaml, name: firmware-ble-beta }
+    uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df # 2026.4.1
+    with:
+      files: ${{ matrix.yaml }}
+      esphome-version: stable
+      combined-name: ${{ matrix.name }}
+      release-version: ${{ needs.version.outputs.v }}
+
+  publish-beta:
+    name: Publish beta release assets
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: fw
+          pattern: firmware*
+
+      - name: Ensure rolling 'beta-fw' pre-release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view beta-fw -R "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create beta-fw -R "${{ github.repository }}" \
+                 --prerelease --title "Beta (rolling)" \
+                 --notes "Latest MSR-2 beta firmware. Auto-updated on every push to the beta branch."
+
+      - name: Rewrite manifests to absolute URLs and upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="https://github.com/${{ github.repository }}/releases/download/beta-fw"
+          declare -A DIRS=( [standard]=firmware-standard [ble]=firmware-ble-beta )
+          for v in standard ble; do
+            src="fw/${DIRS[$v]}"
+            man=$(find "$src" -name manifest.json | head -1)
+            if [ -z "$man" ]; then
+              echo "::error::manifest.json not found for ${DIRS[$v]}"
+              exit 1
+            fi
+            # Both variants share a device name, so their bin filenames match.
+            # Release assets are a flat namespace: prefix per variant.
+            find "$src" -name '*.bin' | while read -r bin; do
+              mv "$bin" "$(dirname "$bin")/$v-$(basename "$bin")"
+            done
+            echo "Rewriting $man"
+            # Make ota.path and parts[].path absolute release-asset URLs so the
+            # device never has to resolve a relative path against a redirect.
+            jq --arg base "$BASE" --arg pfx "$v-" '
+              .builds[0].ota.path = ($base + "/" + $pfx + (.builds[0].ota.path | sub(".*/"; "")))
+              | .builds[0].parts |= map(.path = ($base + "/" + $pfx + (.path | sub(".*/"; ""))))
+            ' "$man" > "manifest-$v.json"
+            cat "manifest-$v.json"
+            gh release upload beta-fw "manifest-$v.json" -R "${{ github.repository }}" --clobber
+            find "$src" -name '*.bin' -print -exec \
+              gh release upload beta-fw {} -R "${{ github.repository }}" --clobber \;
+          done
+          echo "Beta assets published."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,13 @@ jobs:
       pull-requests: write
     with:
       device-name: msr-2
+      # MSR-2.yaml is the end-user image served at firmware/ (OTA updates). The Factory image (improv +
+      # factory test) is only used for first flashes via the web installer.
       yaml-files: |
+        Integrations/ESPHome/MSR-2.yaml
         Integrations/ESPHome/MSR-2_Factory.yaml
         Integrations/ESPHome/MSR-2_BLE.yaml
-      firmware-names: "2_Factory:firmware,2_BLE:firmware-ble"
+      firmware-names: "2:firmware,2_Factory:firmware-factory,2_BLE:firmware-ble"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,19 +1,71 @@
 substitutions:
   name: apollo-msr-2
-  version: "26.6.10.1"
+  version: "26.7.12.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
-  
+  # Default update channel on first boot (no stored user choice yet, i.e. a
+  # fresh flash). The beta-channel builds override this to "Beta" (see
+  # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
+  # channel keeps tracking it instead of offering a stable "downgrade".
+  firmware_channel_default: "Stable"
+  # Manifest URL bases. Stable = GitHub Pages (main branch builds).
+  # Beta = rolling "beta-fw" pre-release assets (beta branch builds).
+  stable_manifest_base: "https://apolloautomation.github.io/MSR-2"
+  beta_manifest_base: "https://github.com/ApolloAutomation/MSR-2/releases/download/beta-fw"
+  # Per-variant OTA manifest URLs. Core defaults to the unified (standard)
+  # image; MSR-2_BLE.yaml overrides these so legacy BLE devices stay on the
+  # firmware-ble manifest.
+  ota_stable_manifest: "${stable_manifest_base}/firmware/manifest.json"
+  ota_beta_manifest: "${beta_manifest_base}/manifest-standard.json"
+
+esphome:
+  # List form so package merging concatenates with each variant's own on_boot
+  # entries (mapping form would be replaced by the variant's block instead).
+  on_boot:
+    - priority: -100
+      then:
+        - script.execute: apply_ota_source
+    # Re-apply the Bluetooth Proxy switch after all components set up, so BLE
+    # scanning matches the persisted switch (proxy stays off by default).
+    - priority: -300
+      then:
+        - if:
+            condition:
+              switch.is_on: bluetooth_proxy_switch
+            then:
+              - esp32_ble_tracker.start_scan:
+                  continuous: true
+            else:
+              - esp32_ble_tracker.stop_scan:
+
 esp32:
   variant: esp32c3
   flash_size: 4MB
   framework:
     type: esp-idf
 
+esp32_ble_tracker:
+  id: ble_tracker
+  scan_parameters:
+    continuous: true
+
+bluetooth_proxy:
+
 captive_portal:
 
 web_server:
   port: 80
   version: 3
+
+http_request:
+  verify_ssl: true
+  # GitHub release-asset downloads answer with a redirect carrying a
+  # ~3.6 KB Content-Security-Policy header; each header line must fit
+  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 5120
+  # The redirect target is a signed URL with a ~850-char query string; the
+  # follow-up request line must fit the TX buffer or esp_http_client_open
+  # fails with "Out of buffer" before sending anything.
+  buffer_size_tx: 2048
 
 globals:
   - id: button_press_timestamp
@@ -720,6 +772,21 @@ button:
           value: 420
           id: scd40
 
+  - platform: template
+    name: "Firmware Update"
+    id: update_firmware
+    icon: mdi:cloud-download
+    entity_category: "config"
+    on_press:
+      - logger.log: "Applying firmware update for the selected channel"
+      - delay: 3s
+      - script.execute: apply_ota_source
+      - script.wait: apply_ota_source
+      # The manifest fetch runs in its own task; give it a fixed window to land
+      # (update.is_available stays false for same-version switches).
+      - delay: 5s
+      - lambda: id(update_http_request).perform(true);
+
 
 interval:
   - interval: 1s
@@ -785,6 +852,19 @@ switch:
             id: setCo2AutoCalibration
             enable: false
 
+  - platform: template
+    name: "Bluetooth Proxy"
+    id: bluetooth_proxy_switch
+    icon: mdi:bluetooth
+    entity_category: "config"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - esp32_ble_tracker.start_scan:
+          continuous: true
+    on_turn_off:
+      - esp32_ble_tracker.stop_scan:
+
 
 text_sensor:
   - platform: ld2410
@@ -812,9 +892,36 @@ select:
       name: "ld2410 Gate Size"
       disabled_by_default: true
 
+  - platform: template
+    name: "Firmware Channel"
+    id: firmware_channel
+    icon: mdi:source-branch
+    entity_category: "config"
+    optimistic: true
+    restore_value: true
+    options:
+      - "Stable"
+      - "Beta"
+    initial_option: "${firmware_channel_default}"
+    on_value:
+      then:
+        - script.execute: apply_ota_source
+
 
 
 script:
+  - id: apply_ota_source
+    # Sets the OTA manifest URL from the Firmware Channel select (Stable/Beta).
+    # The manifest base is per-variant (ota_*_manifest substitutions) so legacy
+    # MSR-2_BLE builds keep their firmware-ble manifest.
+    then:
+      - lambda: |-
+          const bool beta = id(firmware_channel).current_option() == "Beta";
+          std::string url = beta ? "${ota_beta_manifest}" : "${ota_stable_manifest}";
+          ESP_LOGI("firmware", "OTA manifest set to: %s", url.c_str());
+          id(update_http_request).set_source_url(url);
+      - component.update: update_http_request
+
   - id: setCo2AutoCalibration
     mode: restart
     parameters:

--- a/Integrations/ESPHome/MSR-2.yaml
+++ b/Integrations/ESPHome/MSR-2.yaml
@@ -49,10 +49,6 @@ wifi:
   ap:
     ssid: "Apollo MSR2 Hotspot"
 
-
-http_request:
-  verify_ssl: true
-
 safe_mode:
 
 update:

--- a/Integrations/ESPHome/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/MSR-2_BLE.yaml
@@ -1,3 +1,8 @@
+substitutions:
+  # Legacy BLE devices keep updating from the firmware-ble manifest.
+  ota_stable_manifest: "https://apolloautomation.github.io/MSR-2/firmware-ble/manifest.json"
+  ota_beta_manifest: "https://github.com/ApolloAutomation/MSR-2/releases/download/beta-fw/manifest-ble.json"
+
 esphome:
   name: "${name}"
   friendly_name: Apollo MSR-2
@@ -44,15 +49,6 @@ ota:
     id: ota_esphome
   - platform: http_request
     id: ota_managed
-
-bluetooth_proxy:
-  active: true
-esp32_ble_tracker:
-  scan_parameters:
-    active: false
-
-http_request:
-  verify_ssl: true
 
 safe_mode:
 

--- a/Integrations/ESPHome/MSR-2_Factory.yaml
+++ b/Integrations/ESPHome/MSR-2_Factory.yaml
@@ -52,9 +52,6 @@ ota:
   - platform: http_request
     id: ota_managed
 
-http_request:
-  verify_ssl: true
-
 safe_mode:
 
 update:

--- a/Integrations/ESPHome/beta-channel/MSR-2.yaml
+++ b/Integrations/ESPHome/beta-channel/MSR-2.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of MSR-2.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use MSR-2.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../MSR-2.yaml

--- a/Integrations/ESPHome/beta-channel/MSR-2_BLE.yaml
+++ b/Integrations/ESPHome/beta-channel/MSR-2_BLE.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of MSR-2_BLE.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use MSR-2_BLE.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../MSR-2_BLE.yaml

--- a/static/index.html
+++ b/static/index.html
@@ -82,7 +82,7 @@
       <h1>Apollo MSR-2 Installer</h1>
       
       <p class="button-row" align="center">
-                 <esp-web-install-button manifest="./firmware/manifest.json"></esp-web-install-button>
+                 <esp-web-install-button manifest="./firmware-factory/manifest.json"></esp-web-install-button>
       </p>
 
       <div class="footer">


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.7.12.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Ports the MSR-1 unified-firmware redesign (shipped there as 26.7.9.1 — ApolloAutomation/MSR-1#100, ApolloAutomation/MSR-1#103, ApolloAutomation/MSR-1#104) to MSR-2. One image per channel replaces the standard/_BLE build split:

- `bluetooth_proxy` + `esp32_ble_tracker` now compile into every variant. A new "Bluetooth Proxy" switch (default off, persisted) starts/stops scanning at runtime; `esp32_improv` on the Factory image keeps working because the BLE stack stays up.
- New "Firmware Channel" select (Stable/Beta) + `apply_ota_source`: a direct `set_source_url` swap. No `ble_firmware` selector, no manifest-matching guard, and no pre-OTA BLE disable (ESPHome's OTA quiesces BLE itself).
- `http_request` consolidated into Core.yaml with `buffer_size_rx: 5120` / `buffer_size_tx: 2048` — GitHub release redirects overflow the 512-byte defaults (~3.6 KB CSP header line, ~850-char signed query string).
- `MSR-2_BLE.yaml` stays for existing BLE installs; substitution overrides keep them on the `firmware-ble/` manifests.
- `beta-channel/` wrappers default the select to Beta; new build-beta.yml publishes `manifest-standard.json` / `manifest-ble.json` (absolute asset URLs) to a rolling `beta-fw` pre-release. The tag is deliberately not named `beta`: a tag sharing a branch name shadows the branch for `git fetch` and ESPHome remote packages.
- build.yml: the end-user MSR-2.yaml image now publishes to `firmware/`; the improv Factory image moves to `firmware-factory/`; `static/index.html` repointed to match. install.apolloautomation.com needs the same repoint when this ships to main (mirrors MSR-1 installer PR ApolloAutomation/installer#16).

Flash fit: today's MSR-2_BLE image already carries web_server + bluetooth_proxy and builds green, so the unified content is known to fit on the 4MB C3; CI here re-measures all three variants.

Supersedes #79.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stable/Beta firmware channel selection with automatic OTA source updates.
  * Added a manual “Firmware Update” control.
  * Added a Bluetooth Proxy switch to control BLE scanning.
  * Added beta-channel firmware builds for standard and BLE devices.
  * Added support for publishing standard, factory, and BLE firmware variants.

* **Improvements**
  * Updated the web installer to load the factory firmware package.
  * Improved startup behavior so firmware channel and Bluetooth settings are restored automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->