### PR TITLE
Enable API encryption

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-msr-2
-  version: "26.7.12.1"
+  version: "26.7.14.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default update channel on first boot (no stored user choice yet, i.e. a
   # fresh flash). The beta-channel builds override this to "Beta" (see
@@ -104,6 +104,7 @@ globals:
 # Enable Home Assistant API
 # Also Add Buzzer Action Connection
 api:
+  encryption:
   actions:
     - action: play_buzzer
       variables:


### PR DESCRIPTION
Version: 26.7.14.1

## What does this implement/fix?

Adds an empty `encryption:` key to the `api:` block so ESPHome/Home Assistant provisions a per-device API key at adoption, matching MSR-1 and the rest of the fleet. Bumps the firmware version to 26.7.14.1.

Note: freshly flashed devices provision the key seamlessly at adoption. Already-adopted devices will need the auto-generated key entered in Home Assistant after the OTA (a re-adopt) before the API reconnects.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
