### PR TITLE
Remove duplicate label-check job from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,11 @@ on:
   pull_request:
 
 permissions:
-  pull-requests: write
-  issues: write
   contents: read
 
+# Label check lives in label-check.yml on pull_request_target so it can
+# label fork-submitted PRs; plain pull_request tokens are read-only there.
 jobs:
-  label-check:
-    name: Label Check
-    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main
-
   ci:
     name: CI
     uses: ApolloAutomation/Workflows/.github/workflows/esphome-ci.yml@main


### PR DESCRIPTION
Version: N/A (workflow-only, does not publish)

## What does this implement/fix?

Removes the redundant `label-check` job from `ci.yml`. It duplicates the standalone `label-check.yml` (which runs on `pull_request_target`) and always **fails on fork-submitted PRs**, because `pull_request` grants forks a read-only token that cannot apply labels. This is the failing "Label Check" people have been seeing on fork PRs.

Also trims the now-unneeded `pull-requests: write` / `issues: write` permissions. This matches the already-clean `ci.yml` on MSR-1 and CAST-1's `main`.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [x] Github workflows - Does not publish

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
