### PR TITLE
Merge beta into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,11 @@ on:
   pull_request:
 
 permissions:
-  pull-requests: write
-  issues: write
   contents: read
 
+# Label check lives in label-check.yml on pull_request_target so it can
+# label fork-submitted PRs; plain pull_request tokens are read-only there.
 jobs:
-  label-check:
-    name: Label Check
-    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main
-
   ci:
     name: CI
     uses: ApolloAutomation/Workflows/.github/workflows/esphome-ci.yml@main

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-msr-2
-  version: "26.7.12.1"
+  version: "26.7.14.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
   # Default update channel on first boot (no stored user choice yet, i.e. a
   # fresh flash). The beta-channel builds override this to "Beta" (see
@@ -104,6 +104,7 @@ globals:
 # Enable Home Assistant API
 # Also Add Buzzer Action Connection
 api:
+  encryption:
   actions:
     - action: play_buzzer
       variables:


### PR DESCRIPTION
Sync `beta` into `main` to promote the latest merged work:

- API encryption enabled (Core.yaml `encryption:`, #86)
- CI workflow cleanup: duplicate `label-check` job removed from `ci.yml` (#87)

Version bump: **26.7.14.1** (from the encryption change in #86).

This also realigns `main` with `beta` so the two branches stop diverging (the divergence is what previously reintroduced the failing duplicate label-check).

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
